### PR TITLE
Fixed encoding typo.

### DIFF
--- a/tasks/lib/jjencode.coffee
+++ b/tasks/lib/jjencode.coffee
@@ -39,13 +39,13 @@ module.exports = class JJEncode
           if s then r += "\"#{s}\"+"
           r += "#{gv}._$+"
           s = ""
-      else if( n is 0x74 ) # 'u'
+      else if( n is 0x74 ) # 't'
           if s then r += "\"#{s}\"+"
           r += "#{gv}.__+"
           s = ""
       else if( n is 0x75 ) # 'u'
           if s then r += "\"#{s}\"+"
-          r += "#{gv}.__+"
+          r += "#{gv}._+"
           s = ""
       else if ( n < 128 )
           if s then r += "\"#{s}" else r += "\""


### PR DESCRIPTION
Hi,

There seems to be an issue with the encoding part of your jjencode library. The hex code for the letter 't' is also used for the letter 'u'. This pull request fixed the problem.
